### PR TITLE
SysKit changes to the MSCloudLoginAssistant

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -12,7 +12,7 @@
     RootModule = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.2'
+    ModuleVersion = '1.0.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -51,12 +51,9 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules = @(@{
-        ModuleName      = "AzureAD"
-        RequiredVersion = "2.0.2.4"
-    })
+     # RequiredModules = @()
 
-    # Assemblies that must be loaded prior to importing this module
+    # Assemblies that must be loaded prior to importing this module    
     # RequiredAssemblies = @()
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
@@ -79,7 +76,8 @@
         'Workloads\SecurityCompliance.psm1',
         'Workloads\SharePointOnline.psm1',
         'Workloads\SkypeForBusiness.psm1',
-        'Workloads\Teams.psm1'
+        'Workloads\Teams.psm1',
+        'Utilities\Adal.psm1'
     )
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -12,7 +12,7 @@
     RootModule = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.0'
+    ModuleVersion = '1.0.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -51,7 +51,10 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-     # RequiredModules = @()
+    RequiredModules = @(@{
+        ModuleName      = "AzureAD"
+        RequiredVersion = "2.0.2.4"	
+    })
 
     # Assemblies that must be loaded prior to importing this module    
     # RequiredAssemblies = @()

--- a/Modules/MSCloudLoginAssistant/Utilities/Adal.psm1
+++ b/Modules/MSCloudLoginAssistant/Utilities/Adal.psm1
@@ -1,0 +1,180 @@
+
+function Get-AzureADDLL
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+    )
+    [array]$AzureADModules = Get-Module -ListAvailable | Where-Object {$_.name -eq "AzureAD"}
+    if ($AzureADModules.count -eq 0)
+    {
+        Throw "Can't find Azure AD DLL. Install the module manually 'Install-Module AzureAD'"
+    }
+    else
+    {
+        $AzureDLL = Join-Path (($AzureADModules | Sort-Object version -Descending | Select-Object -first 1).Path | split-Path) Microsoft.IdentityModel.Clients.ActiveDirectory.dll
+        return $AzureDLL
+    }
+}
+
+# very ugly, but all my attempts to set the afteraccess and beforeaccess handlers have failed in powershell
+# either it hangs the session, or throws that there is no runspace available(since the auth is happening on a different thread), or it simply ignored my attemtps
+# since this is pure C# it should work
+# an alternate version would be to load a precompiled dll, but chose to go with this current option because of simplicity of the class
+$charpCode="
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace ADAL
+{
+    public class FilePersistedTokenCache : TokenCache
+    {
+        public string CacheFilePath { get; private set; }
+        private static readonly object FileLock = new object();
+        
+        public FilePersistedTokenCache(string filePath)
+        {
+            CacheFilePath = filePath;
+            this.AfterAccess = AfterAccessNotification;
+            this.BeforeAccess = BeforeAccessNotification;
+            lock (FileLock)
+            {
+                this.Deserialize(ReadFromFileIfExists(CacheFilePath));
+            }
+        }
+        
+        public override void Clear()
+        {
+            base.Clear();
+            File.Delete(CacheFilePath);
+        }
+        
+        void BeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            lock (FileLock)
+            {
+                this.Deserialize(ReadFromFileIfExists(CacheFilePath));
+            }
+        }
+        
+        void AfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            // if the access operation resulted in a cache update
+            if (this.HasStateChanged)
+            {
+                lock (FileLock)
+                {
+                    // reflect changes in the persistent store
+                    WriteToFileIfNotNull(CacheFilePath, this.Serialize());
+                    // once the write operation took place, restore the HasStateChanged bit to false
+                    this.HasStateChanged = false;
+                }
+            }
+        }
+
+        private byte[] ReadFromFileIfExists(string path)
+        {
+            byte[] protectedBytes = (!string.IsNullOrEmpty(path) && File.Exists(path)) 
+                ? File.ReadAllBytes(path) : null;
+            byte[] unprotectedBytes = (protectedBytes != null) 
+                ? ProtectedData.Unprotect(protectedBytes, null, DataProtectionScope.CurrentUser) : null;
+            return unprotectedBytes;
+        }
+
+        private static void WriteToFileIfNotNull(string path, byte[] blob)
+        {
+            if (blob != null)
+            {
+                byte[] protectedBytes = ProtectedData.Protect(blob, null, DataProtectionScope.CurrentUser);
+                File.WriteAllBytes(path, protectedBytes);
+            }
+            else
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}"
+
+
+function Get-PersistedTokenCacheInstance
+{
+    Param(
+        [Parameter(Mandatory = $True)]        
+        $FilePath
+    )
+
+    if (!([System.Management.Automation.PSTypeName]'ADAL.FilePersistedTokenCache').Type)   
+    {
+     
+        try
+        {
+            # there are some very nasty problems with the fact that there are multiple versions of ADAL dll being used            
+            # across all of the platforms
+            # if we just pass the adaldlllocation then  ie. when calling acquireToken it would say that it cannot find the method out of the blue after a couple of calls            
+            # for the compilation step and the load type step we simply forward the currently loaded assembly
+            $onAssemblyResolveEventHandler = [ResolveEventHandler]{
+                param($sender, $e)
+            
+                Write-Verbose "ResolveEventHandler: Attempting FullName resolution of $($e.Name)" 
+                foreach($assembly in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
+                    if ($assembly.FullName -eq $e.Name) {
+                        Write-Host "Successful FullName resolution of $($e.Name)" 
+                        return $assembly
+                    }
+                }
+            
+                Write-Verbose "ResolveEventHandler: Attempting name-only resolution of $($e.Name)" 
+                foreach($assembly in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
+                    # Get just the name from the FullName (no version)
+                    $assemblyName = $assembly.FullName.Substring(0, $assembly.FullName.IndexOf(", "))
+            
+                    if ($e.Name.StartsWith($($assemblyName + ","))) {
+            
+                        Write-Verbose "Successful name-only (no version) resolution of $assemblyName" 
+                        return $assembly
+                    }
+                }
+                            
+                return $null
+            }
+            
+            try
+            {
+                [System.AppDomain]::CurrentDomain.add_AssemblyResolve($onAssemblyResolveEventHandler)
+
+                   # $location = [PsObject].Assembly.Location
+                $adalDLLLocation = Get-AzureADDLL
+                $compileParams = New-Object System.CodeDom.Compiler.CompilerParameters
+                $assemblyRange = @("System.dll", "System.Security.dll", "System.Core.dll", "System.Threading.dll", $adalDLLLocation, $location)
+                $compileParams.ReferencedAssemblies.AddRange($assemblyRange)
+                $compileParams.GenerateInMemory = $True    
+
+                try
+                {
+                    Add-Type -TypeDefinition $charpCode -CompilerParameters $compileParams -passthru  | Out-Null 
+                }
+                catch
+                {
+
+                }
+
+
+                # if we wanted to use a precompiled dll
+                # chose to just compile the code dynamically because it seems easier to mantain for such a simple class
+                #Add-Type -Path "$PSScriptRoot\ADAL.FilePersistedTokenCache.dll"
+            }            
+            finally
+            {
+                [System.AppDomain]::CurrentDomain.remove_AssemblyResolve($onAssemblyResolveEventHandler)
+            }
+        }
+        catch
+        {
+            Write-Error $_   
+        }        
+    }
+         
+    return New-Object "ADAL.FilePersistedTokenCache" -ArgumentList $FilePath 
+}

--- a/Modules/MSCloudLoginAssistant/Utilities/DelegatedPowerAppsAuth/Microsoft.PowerApps.AuthModule.psm1
+++ b/Modules/MSCloudLoginAssistant/Utilities/DelegatedPowerAppsAuth/Microsoft.PowerApps.AuthModule.psm1
@@ -1,0 +1,366 @@
+$local:ErrorActionPreference = "Stop"
+
+function Get-JwtTokenClaims
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory=$true)]
+        [string]$JwtToken
+    )
+
+    $tokenSplit = $JwtToken.Split(".")
+    $claimsSegment = $tokenSplit[1].Replace(" ", "+");
+    
+    $mod = $claimsSegment.Length % 4
+    if ($mod -gt 0)
+    {
+        $paddingCount = 4 - $mod;
+        for ($i = 0; $i -lt $paddingCount; $i++)
+        {
+            $claimsSegment += "="
+        }
+    }
+
+    $decodedClaimsSegment = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($claimsSegment))
+
+    return ConvertFrom-Json $decodedClaimsSegment
+}
+
+function Add-PowerAppsAccount
+{
+    [CmdletBinding()]
+    param
+    (
+        [string] $Audience = "https://management.azure.com/",
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("prod","preview","tip1", "tip2", "usgov", "usgovhigh")]
+        [string]$Endpoint = "prod",
+
+        [string]$Username = $null
+    )   
+
+    if(!$Username)
+    {
+        $Username = $Global:appIdentityParams.OnBehalfOfUserPrincipalName
+    }
+
+    
+    $powerAppsAudience = "https://management.azure.com/"
+    $authResult = Get-OnBehalfOfAuthResult -TargetUri $powerAppsAudience -UserPrincipalName $Username -ErrorAction Stop
+    
+    # this global object is an object populated from the PowerApps PowerShell module 
+    # not sure why they didn't name it a bit more descriptive to avoid collisions
+    # anyhow, if we set this than the module works with our custom tokens and our AppId without dealing with the Add-PowerAppsAccount cmdlet
+    # and we also avoid the old ADAL version
+    $global:currentSession = @{
+        customModuleLoaded = $true
+        loggedIn = $true
+        tenantId = $authResult.TenantId
+        upn = $authResult.Account.Username            
+        userId = $authResult.UniqueId        
+        expiresOn = (Get-Date).AddHours(8)
+        resourceTokens = @{
+            $powerAppsAudience = @{
+                accessToken = $authResult.AccessToken                    
+                expiresOn = $authResult.ExpiresOn
+            }
+        }
+        selectedEnvironment = "~default"
+        flowEndpoint = 
+            switch ($Endpoint)
+            {
+                "prod"      { "api.flow.microsoft.com" }
+                "usgov"     { "gov.api.flow.microsoft.us" }
+                "usgovhigh" { "high.api.flow.microsoft.us" }
+                "preview"   { "preview.api.flow.microsoft.com" }
+                "tip1"      { "tip1.api.flow.microsoft.com"}
+                "tip2"      { "tip2.api.flow.microsoft.com" }
+                default     { throw "Unsupported endpoint '$Endpoint'"}
+            }
+        powerAppsEndpoint = 
+            switch ($Endpoint)
+            {
+                "prod"      { "api.powerapps.com" }
+                "usgov"     { "gov.api.powerapps.us" }
+                "usgovhigh" { "high.api.powerapps.us" }
+                "preview"   { "preview.api.powerapps.com" }
+                "tip1"      { "tip1.api.powerapps.com"}
+                "tip2"      { "tip2.api.powerapps.com" }
+                default     { throw "Unsupported endpoint '$Endpoint'"}
+            }          
+        bapEndpoint = 
+            switch ($Endpoint)
+            {
+                "prod"      { "api.bap.microsoft.com" }
+                "usgov"     { "gov.api.bap.microsoft.us" }
+                "usgovhigh" { "high.api.bap.microsoft.us" }
+                "preview"   { "preview.api.bap.microsoft.com" }
+                "tip1"      { "tip1.api.bap.microsoft.com"}
+                "tip2"      { "tip2.api.bap.microsoft.com" }
+                default     { throw "Unsupported endpoint '$Endpoint'"}
+            }     
+        graphEndpoint = 
+            switch ($Endpoint)
+            {
+                "prod"      { "graph.windows.net" }
+                "usgov"     { "graph.windows.net" }
+                "usgovhigh" { "graph.windows.net" }
+                "preview"   { "graph.windows.net" }
+                "tip1"      { "graph.windows.net"}
+                "tip2"      { "graph.windows.net" }
+                default     { throw "Unsupported endpoint '$Endpoint'"}
+            }
+        cdsOneEndpoint = 
+            switch ($Endpoint)
+            {
+                "prod"      { "api.cds.microsoft.com" }
+                "usgov"     { "gov.api.cds.microsoft.us" }
+                "usgovhigh" { "high.api.cds.microsoft.us" }
+                "preview"   { "preview.api.cds.microsoft.com" }
+                "tip1"      { "tip1.api.cds.microsoft.com"}
+                "tip2"      { "tip2.api.cds.microsoft.com" }
+                default     { throw "Unsupported endpoint '$Endpoint'"}
+            }
+    };
+}
+
+function Test-PowerAppsAccount
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    if (-not $global:currentSession)
+    {
+        Add-PowerAppsAccount
+    }
+}
+
+function Remove-PowerAppsAccount
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    if ($global:currentSession -ne $null -and $global:currentSession.upn -ne $null)
+    {
+        Write-Verbose "Logging out $($global:currentSession.upn)"
+    }
+    else
+    {
+        Write-Verbose "No user logged in"
+    }
+
+    $global:currentSession = @{
+        loggedIn = $false;
+    };
+}
+
+function Get-JwtToken
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory=$true)]
+        [string] $Audience
+    )
+
+    if ($global:currentSession -eq $null)
+    {
+        $global:currentSession = @{
+            loggedIn = $false;
+        };
+    }
+
+    $authResult = Get-OnBehalfOfAuthResult -TargetUri $Audience -UserPrincipalName $global:currentSession.upn -ErrorAction Stop
+
+    $global:currentSession.resourceTokens[$Audience] = @{
+        accessToken = $authResult.AccessToken;
+        expiresOn = $authResult.ExpiresOn;
+    }
+
+    return $global:currentSession.resourceTokens[$Audience].accessToken;
+}
+
+function Invoke-OAuthDialog
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory=$true)]
+        [string] $ConsentLinkUri
+    )
+
+   
+    $output = @{}
+    
+    return $output
+}
+
+
+function Get-TenantDetailsFromGraph
+{
+ <#
+ .SYNOPSIS
+ .
+ .DESCRIPTION
+ The Get-TenantDetailsFromGraph function . 
+ Use Get-Help Get-TenantDetailsFromGraph -Examples for more detail.
+ .EXAMPLE
+ Get-TenantDetailsFromGraph
+ .
+ #>
+    param
+    (
+        [string]$GraphApiVersion = "1.6"
+    )
+
+    process 
+    {
+        $TenantIdentifier = "myorganization"
+
+        $route = "https://{graphEndpoint}/{tenantIdentifier}/tenantDetails`?api-version={graphApiVersion}" `
+        | ReplaceMacro -Macro "{tenantIdentifier}" -Value $TenantIdentifier `
+        | ReplaceMacro -Macro "{graphApiVersion}" -Value $GraphApiVersion;
+
+        $graphResponse = InvokeApi -Method GET -Route $route
+        
+        CreateTenantObject -TenantObj $graphResponse.value
+
+    }
+}
+
+#Returns users or groups from Graph
+#wrapper on top of https://msdn.microsoft.com/en-us/library/azure/ad/graph/api/users-operations & https://msdn.microsoft.com/en-us/library/azure/ad/graph/api/groups-operations 
+function Get-UsersOrGroupsFromGraph(
+)
+{
+    [CmdletBinding(DefaultParameterSetName="Id")]
+    param
+    (
+        [Parameter(Mandatory = $true, ParameterSetName = "Id")]
+        [string]$ObjectId,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "Search")]
+        [string]$SearchString,
+
+        [Parameter(Mandatory = $false, ParameterSetName = "Search")]
+        [Parameter(Mandatory = $false, ParameterSetName = "Id")]
+        [string]$GraphApiVersion = "1.6"
+    )
+
+    Process
+    {
+        if (-not [string]::IsNullOrWhiteSpace($ObjectId))
+        {
+            $userGraphUri = "https://graph.windows.net/myorganization/users/{userId}`?&api-version={graphApiVersion}" `
+            | ReplaceMacro -Macro "{userId}" -Value $ObjectId `
+            | ReplaceMacro -Macro "{graphApiVersion}" -Value $GraphApiVersion;
+
+            $userGraphResponse = InvokeApi -Route $userGraphUri -Method GET
+            
+            If($userGraphResponse.StatusCode -eq $null)
+            {
+                CreateUserObject -UserObj $userGraphResponse
+            }
+
+            $groupsGraphUri = "https://graph.windows.net/myorganization/groups/{groupId}`?api-version={graphApiVersion}" `
+            | ReplaceMacro -Macro "{groupId}" -Value $ObjectId `
+            | ReplaceMacro -Macro "{graphApiVersion}" -Value $GraphApiVersion;
+
+            $groupGraphResponse = InvokeApi -Route $groupsGraphUri -Method GET
+
+            If($groupGraphResponse.StatusCode -eq $null)
+            {
+                CreateGroupObject -GroupObj $groupGraphResponse
+            }
+        }
+        else 
+        {
+            $userFilter = "startswith(userPrincipalName,'$SearchString') or startswith(displayName,'$SearchString')"
+    
+            $userGraphUri = "https://graph.windows.net/myorganization/users`?`$filter={filter}&api-version={graphApiVersion}" `
+            | ReplaceMacro -Macro "{filter}" -Value $userFilter `
+            | ReplaceMacro -Macro "{graphApiVersion}" -Value $GraphApiVersion;
+
+            $userGraphResponse = InvokeApi -Route $userGraphUri -Method GET
+    
+            foreach($user in $userGraphResponse.value)
+            {
+                CreateUserObject -UserObj $user
+            }
+
+            $groupFilter = "startswith(displayName,'$SearchString')"
+    
+            $groupsGraphUri = "https://graph.windows.net/myorganization/groups`?`$filter={filter}&api-version={graphApiVersion}" `
+            | ReplaceMacro -Macro "{filter}" -Value $groupFilter `
+            | ReplaceMacro -Macro "{graphApiVersion}" -Value $GraphApiVersion;
+
+            $groupsGraphResponse = Invoke-Request -Uri $groupsGraphUri -Method GET -ParseContent -ThrowOnFailure
+    
+            foreach($group in $groupsGraphResponse.value)
+            {
+                CreateGroupObject -GroupObj $group
+            }    
+        }
+    }
+}
+
+
+function CreateUserObject
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [object]$UserObj
+    )
+
+    return New-Object -TypeName PSObject `
+        | Add-Member -PassThru -MemberType NoteProperty -Name ObjectType -Value $UserObj.objectType `
+        | Add-Member -PassThru -MemberType NoteProperty -Name ObjectId -Value $UserObj.objectId `
+        | Add-Member -PassThru -MemberType NoteProperty -Name UserPrincipalName -Value $UserObj.userPrincipalName `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Mail -Value $UserObj.mail `
+        | Add-Member -PassThru -MemberType NoteProperty -Name DisplayName -Value $UserObj.displayName `
+        | Add-Member -PassThru -MemberType NoteProperty -Name AssignedLicenses -Value $UserObj.assignedLicenses `
+        | Add-Member -PassThru -MemberType NoteProperty -Name AssignedPlans -Value $UserObj.assignedLicenses `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Internal -Value $UserObj;
+}
+
+function CreateGroupObject
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [object]$GroupObj
+    )
+
+    return New-Object -TypeName PSObject `
+        | Add-Member -PassThru -MemberType NoteProperty -Name ObjectType -Value $GroupObj.objectType `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Objectd -Value $GroupObj.objectId `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Mail -Value $GroupObj.mail `
+        | Add-Member -PassThru -MemberType NoteProperty -Name DisplayName -Value $GroupObj.displayName `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Internal -Value $GroupObj;
+}
+
+
+function CreateTenantObject
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [object]$TenantObj
+    )
+
+    return New-Object -TypeName PSObject `
+        | Add-Member -PassThru -MemberType NoteProperty -Name ObjectType -Value $TenantObj.objectType `
+        | Add-Member -PassThru -MemberType NoteProperty -Name TenantId -Value $TenantObj.objectId `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Country -Value $TenantObj.countryLetterCode `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Language -Value $TenantObj.preferredLanguage `
+        | Add-Member -PassThru -MemberType NoteProperty -Name DisplayName -Value $TenantObj.displayName `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Domains -Value $TenantObj.verifiedDomains `
+        | Add-Member -PassThru -MemberType NoteProperty -Name Internal -Value $TenantObj;
+}

--- a/Modules/MSCloudLoginAssistant/Workloads/Azure.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Azure.psm1
@@ -3,17 +3,30 @@ function Connect-MSCloudLoginAzure
     [CmdletBinding()]
     param()
     try
-    {
-        if ($null -ne $Global:o365Credential)
+    {        
+        if (!$Global:UseApplicationIdentity -and $null -ne $Global:o365Credential)
         {
-            Connect-AzAccount -Credential $Global:o365Credential -ErrorAction Stop | Out-Null
-            $Global:MSCloudLoginAzureConnected = $True
+            Connect-AzAccount -Credential $Global:o365Credential -ErrorAction Stop | Out-Null            
+        }        
+        elseif ($Global:UseApplicationIdentity)
+        {
+            if($Global:appIdentityParams.CertificateThumbprint) 
+            {
+                Connect-AzAccount -ApplicationId $Global:appIdentityParams.AppId -Tenant $Global:appIdentityParams.Tenant -CertificateThumbprint $Global:appIdentityParams.CertificateThumbprint  -ErrorAction Stop | Out-Null
+                Write-Verbose "Connected to Azure using application identity with certificate thumbprint"            
+            }
+            else
+            {
+                Connect-AzAccount -Credential $Global:appIdentityParams.ServicePrincipalCredentials -Tenant $Global:appIdentityParams.Tenant -ServicePrincipal  -ErrorAction Stop | Out-Null
+                Write-Verbose "Connected to Azure using application identity with application secret"            
+            }
         }
         else
         {
             Connect-AzAccount -ErrorAction Stop | Out-Null
-            $Global:MSCloudLoginAzureConnected = $True
         }
+        
+        $Global:MSCloudLoginAzureConnected = $True
     }
     catch 
     {

--- a/Modules/MSCloudLoginAssistant/Workloads/AzureAD.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/AzureAD.psm1
@@ -4,7 +4,25 @@ function Connect-MSCloudLoginAzureAD
     param()
     try 
     {
-        Connect-AzureAD -Credential $Global:o365Credential -ErrorAction Stop | Out-Null
+        if ($Global:UseApplicationIdentity)
+        {
+            if($Global:appIdentityParams.CertificateThumbprint) 
+            {
+                Connect-AzureAD -TenantId $Global:appIdentityParams.Tenant -ApplicationId $Global:appIdentityParams.AppId -CertificateThumbprint $Global:appIdentityParams.CertificateThumbprint -ErrorAction Stop | Out-Null            
+                Write-Verbose "Connected to AzureAD using application identity with certificate thumbprint"            
+            }
+            else
+            {                
+                # actually it probably can do so by getting the access token manually, but for now we want it to work with the certificate
+                throw "The AzureAD Platform does not support connecting with application secret"
+            }            
+        }
+        else
+        {
+            Connect-AzureAD -Credential $Global:o365Credential -ErrorAction Stop | Out-Null
+            Write-Verbose "Connected to AzureAD using regular authentication"
+        }
+        
         $Global:IsMFAAuth = $false
         $Global:MSCloudLoginAzureADConnected = $true
     }

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
@@ -2,6 +2,11 @@ function Connect-MSCloudLoginExchangeOnline
 {
     [CmdletBinding()]
     param()
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The Exchange Platform does not support connecting with application identity."
+    }
+    
     if ($null -eq $Global:o365Credential)
     {
        $Global:o365Credential = Get-Credential -Message "Cloud Credential"

--- a/Modules/MSCloudLoginAssistant/Workloads/MSOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/MSOnline.psm1
@@ -2,7 +2,11 @@ function Connect-MSCloudLoginMSOnline
 {
     [CmdletBinding()]
     param()
-
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The MSOnline Platform does not support connecting with application identity."
+    }
+    
     if ($null -ne $Global:o365Credential)
     {
         Test-MSCloudLogin -Platform AzureAD -CloudCredential $Global:o365Credential

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -2,6 +2,11 @@ function Connect-MSCloudLoginSecurityCompliance
 {
     [CmdletBinding()]
     param()
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    {
+        throw "The SecurityComplianceCenter Platform does not support connecting with application identity."
+    }
+    
     if ($null -eq $Global:o365Credential)
     {
        $Global:o365Credential = Get-Credential -Message "Cloud Credential"

--- a/Modules/MSCloudLoginAssistant/Workloads/SharePointOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SharePointOnline.psm1
@@ -2,9 +2,13 @@ function Connect-MSCloudLoginSharePointOnline
 {
     [CmdletBinding()]
     param()
-
-    try
+    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
     {
+        throw "The SharePointOnline Platform does not support connecting with application identity."
+    }
+    
+    try
+    {        
         if ($null -ne $Global:o365Credential)
         {
             if ([string]::IsNullOrEmpty($ConnectionUrl))

--- a/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/Teams.psm1
@@ -3,7 +3,18 @@ function Connect-MSCloudLoginTeams
     [CmdletBinding()]
     param()
 
-    if ($null -ne $Global:o365Credential)
+    if ($Global:UseApplicationIdentity)
+    {    
+        if($Global:appIdentityParams.CertificateThumbprint) 
+        {
+            Connect-MicrosoftTeams -TenantId $Global:appIdentityParams.Tenant -ApplicationId $Global:appIdentityParams.AppId -CertificateThumbprint $Global:appIdentityParams.CertificateThumbprint -ErrorAction Stop | Out-Null                
+        }
+        else
+        {
+            throw "The MicrosoftTeams Platform does not support connecting with application secret"
+        }
+    }
+    elseif ($null -ne $Global:o365Credential)
     {
         if ($Global:o365Credential.UserName.Split('@')[1] -like '*.de')
         {


### PR DESCRIPTION
This PR contains all of the changes that we made to the MSCloudLoginAssistant up until now.

Highlights:
- application identity support for Azure, AzureAD, Pnp, Teams workloads
- delegated permissions support for SkypeForBusiness, PowerPlatform
- ExchangeOnline & security and compliance needs to go through app passwords 

The powerapps authentication module is replaced with our own custom implementation. Not the prettiest solution but it works.


To use these new features one must call `Init-ApplicationIdentity` to setup the application for application identity and delegated permissions.
ie 
```
Init-ApplicationIdentity -Tenant 71184702-e695-4086-9d49-b9d69f237ae8 `
 -AppId 30f8a0d0-12df-46a1-baf0-9497f33b2dd1 `
  -CertificateThumbprint 2484eabc809babb3a5c68a2c65d12a35a241cff4 `
  -TokenCacheLocation '.\tokenCache.dat' `
  -OnBehalfOfUserPrincipalName "someuser@testtenant.onmicrosoft.com"
```
Once its setup, depending on the platform you can call 

Test-MsCloudLogin -Platform {Platform} or 
Test-MsCloudLogin -Platform {Platform} -CloudCredentials $creds with the application password for Exhange and SecurityAndCompliance platforms