### PR TITLE
Gcc high support b/additional app identity

### DIFF
--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -1090,3 +1090,28 @@ function Get-PsModuleAzureEnvironmentName
     return $Global:AzureCloudEnvironments.$AzureCloudEnvironmentName.PsModuleEnvironmentNames.$Platform
 }
 
+function Get-MSCloudLoginOrganizationName
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $TenantId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Test-MSCloudLogin -Platform AzureAD
+
+    $domain = Get-AzureADDomain  | where-object {$_.IsInitial -eq $True} | select Name
+
+    if ($null -ne $domain){
+
+        return $domain.Name
+    }
+}

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
@@ -2,159 +2,70 @@ function Connect-MSCloudLoginExchangeOnline
 {
     [CmdletBinding()]
     param()
-    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
-    {
-        throw "The Exchange Platform does not support connecting with application identity."
-    }
+    $WarningPreference = 'SilentlyContinue'
+    $ProgressPreference = 'SilentlyContinue'
 
-    if ($null -eq $Global:o365Credential)
+    $ExoEnvName = Get-PsModuleAzureEnvironmentName -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -Platform "ExchangeOnline"
+    $ApplicationId = $Global:appIdentityParams.AppId
+    $TenantId = $Global:appIdentityParams.Tenant
+    $CertificateThumbprint = $Global:appIdentityParams.CertificateThumbprint
+    $authorizationUrl = Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName ActiveDirectory
+    $authorizationUrl += "common"    
+    $psConnectionUri =  Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName ExchangePsConnection
+    $uriObj = [Uri]::new($psConnectionUri)
+    $exchangeHost = $uriObj.Host
+    [array]$activeSessions = Get-PSSession | Where-Object -FilterScript { ($_.ComputerName -like '*outlook.office*' -or $_.ComputerName -like "*$exchangeHost*" ) -and $_.State -eq 'Opened'}
+    if ($activeSessions.Length -ge 1)
     {
-       $Global:o365Credential = Get-Credential -Message "Cloud Credential"
-    }
-    $VerbosePreference = 'SilentlyContinue'
-    $WarningPreference = "Continue"
-    $clientid = "a0c73c16-a7e3-4564-9a95-2bdf47383716";
-    $ResourceURI = Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName ExchangeResourceId
-    $RedirectURI = "urn:ietf:wg:oauth:2.0:oob";
-    $ClosedOrBrokenSessions = Get-PSSession -ErrorAction SilentlyContinue | Where-Object -FilterScript { $_.State -ne 'Opened' }
-    if ($ClosedOrBrokenSessions)
-    {
-        Write-Verbose -Message "Found Existing Unusable Session(s)."
-        foreach ($SessionToBeClosed in $ClosedOrBrokenSessions)
+        Write-Verbose -Message "Found {$($activeSessions.Length)} existing Exchange Online Session"
+        $command = Get-Command "Get-AcceptedDomain" -ErrorAction 'SilentlyContinue'
+        if ($null -ne $command)
         {
-            Write-Verbose -Message "Closing Session: $(($SessionToBeClosed).InstanceId)"
-            $SessionToBeClosed | Remove-PSSession
+            return
         }
+        $EXOModule = Import-PSSession $activeSessions[0] -DisableNameChecking -AllowClobber
+        Import-Module $EXOModule -Global | Out-Null
+        return
     }
-
-    $Global:OpenExchangeSession = Get-PSSession -Name 'ExchangeOnline' `
-        -ErrorAction SilentlyContinue | `
-            Where-Object -FilterScript { $_.State -eq 'Opened' }
-    if ($null -eq $Global:OpenExchangeSession)
+    Write-Verbose -Message "No active Exchange Online session found."   
+   
+    #endregion
+    if (-not [String]::IsNullOrEmpty($ApplicationId) -and `
+        -not [String]::IsNullOrEmpty($TenantId) -and `
+        -not [String]::IsNullOrEmpty($CertificateThumbprint))
     {
+        Write-Verbose -Message "Attempting to connect to Exchange Online using AAD App {$ApplicationID}"
         try
         {
-            $PowerShellConnections = Get-NetTCPConnection | `
-                Where-Object -FilterScript { `
-                    $_.RemotePort -eq '443' -and $_.State -ne 'Established' `
-                }
-
-            while ($PowerShellConnections)
-            {
-                Write-Verbose -Message "This process is using the following connections in a non-Established state: $($PowerShellConnections | Out-String)"
-                Write-Verbose -Message "Waiting for closing connections to close..."
-                Get-PSSession -Name 'ExchangeOnline' -ErrorAction SilentlyContinue | Remove-PSSession
-                Start-Sleep -seconds 1
-                $CheckConnectionsWithoutKillingWhileLoop = Get-NetTCPConnection | Where-Object -FilterScript { $_.OwningProcess -eq $PID -and $_.RemotePort -eq '443' -and $_.State -ne 'Established' }
-                if (-not $CheckConnectionsWithoutKillingWhileLoop)
-                {
-                    Write-Verbose -Message "Connections have closed.  Waiting 5 more seconds..."
-                    Start-Sleep -seconds 5
-                    $PowerShellConnections = Get-NetTCPConnection | Where-Object -FilterScript { $_.OwningProcess -eq $PID -and $_.RemotePort -eq '443' -and $_.State -ne 'Established' }
-                }
-            }
-
-            if ($Global:ExchangeOnlineSession.State -eq "Closed")
-            {
-                Remove-PSSession $Global:ExchangeOnlineSession
-                $Global:ExchangeOnlineSession = $null
-            }
-
-            if ($null -eq $Global:ExchangeOnlineSession)
-            {
-                Write-Verbose -Message "Creating new EXO Session"
-
-                $psConnectionUri =  Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName ExchangePsConnection
-                try
-                {
-                    $Global:ExchangeOnlineSession = New-PSSession -Name 'ExchangeOnline' -ConfigurationName Microsoft.Exchange -ConnectionUri $psConnectionUri -Credential $O365Credential -Authentication Basic -AllowRedirection -ErrorAction Stop
-                    $Global:IsMFAAuth = $false
-                }
-                catch
-                {
-                    # Exchange Online cannot use our own app identity or delegate so
-                    # we only allow app passwords for Security & compliance
-                    # if the connection fails we do not want to fallback to Modern authentication since
-                    # the script is very likely to be executing within a non interactive environment
-                    if($Global:UseApplicationIdentity)
-                    {
-                        throw $_
-                    }
-                    try
-                    {
-                        $AuthHeader = Get-AuthHeader -UserPrincipalName $Global:o365Credential.UserName -RessourceURI $ResourceURI -clientID $clientID -RedirectURI $RedirectURI
-                        $Password = ConvertTo-SecureString -AsPlainText $AuthHeader -Force
-                        $Ctoken = New-Object System.Management.Automation.PSCredential -ArgumentList $Global:o365Credential.UserName, $Password
-                        $Global:ExchangeOnlineSession = New-PSSession -ConfigurationName Microsoft.Exchange `
-                            -ConnectionUri " $psConnectionUri?BasicAuthToOAuthConversion=true" `
-                            -Credential $Ctoken `
-                            -Authentication Basic `
-                            -ErrorAction Stop `
-                            -AllowRedirection
-                        $Global:UseModernAuth = $True
-                        $Global:IsMFAAuth = $True
-                    }
-                    catch
-                    {
-                        if ($_ -like '*Connecting to remote server *Access is denied.*')
-                        {
-                            Throw "The provided account doesn't have admin access to Exchange Online."
-                        }
-                    }
-                }
-            }
-            if ($null -eq $Global:ExchangeOnlineModules)
-            {
-                Write-Verbose -Message "Importing all commands into the EXO Session"
-                $WarningPreference = 'SilentlyContinue'
-                $Global:ExchangeOnlineModules = Import-PSSession $Global:ExchangeOnlineSession -AllowClobber
-                Import-Module $Global:ExchangeOnlineModules -Global | Out-Null
-            }
+            $Organization = Get-MSCloudLoginOrganizationName -ApplicationId $ApplicationId `
+                -TenantId $TenantId `
+                -CertificateThumbprint $CertificateThumbprint
+            $CurrentVerbosePreference = $VerbosePreference
+            $CurrentInformationPreference = $InformationPreference
+            $CurrentWarningPreference = $WarningPreference
+            $VerbosePreference = "SilentlyContinue"
+            $InformationPreference = "SilentlyContinue"
+            $WarningPreference = "SilentlyContinue"
+            Connect-ExchangeOnline -AppId $ApplicationId `
+                -Organization $Organization `
+                -CertificateThumbprint $CertificateThumbprint `
+                -ShowBanner:$false `
+                -ShowProgress:$false `
+                -ConnectionUri $psConnectionUri `
+                -AzureADAuthorizationEndpointUri $AuthorizationUrl `
+                -ExchangeEnvironmentName $ExoEnvName `
+                -Verbose:$false | Out-Null
+            $VerbosePreference = $CurrentVerbosePreference
+            $InformationPreference = $CurrentInformationPreference
+            $WarningPreference = $CurrentWarningPreference
+            Write-Verbose -Message "Successfully connected to Exchange Online using AAD App {$ApplicationID}"
         }
         catch
         {
-            $ExceptionMessage = $_.Exception
-            $Error.Clear()
-            $VerbosePreference = 'SilentlyContinue'
-            if ($ExceptionMessage -imatch 'Please wait for [0-9]* seconds')
-            {
-                Write-Verbose -Message "Waiting for available runspace..."
-                [regex]$WaitTimePattern = 'Please wait for [0-9]* seconds'
-
-                $WaitTimePatternMatch = (($WaitTimePattern.Match($ExceptionMessage)).Value | `
-                    Select-String -Pattern '[0-9]*' -AllMatches)
-
-                $WaitTimeInSeconds = ($WaitTimePatternMatch | ForEach-Object {$_.Matches} | Where-Object -FilterScript { $_.Value -NotLike $null }).Value
-                Write-Verbose -Message "Waiting for requested $WaitTimeInSeconds seconds..."
-                Start-Sleep -Seconds ($WaitTimeInSeconds + 1)
-                try
-                {
-                    Test-MSCloudLogin -Platform 'ExchangeOnline' -CloudCredential $Global:o365Credential
-                }
-                catch
-                {
-                    $VerbosePreference = 'SilentlyContinue'
-                    $WarningPreference = "SilentlyContinue"
-                    $Global:ExchangeOnlineSession = $null
-                    Close-SessionsAndReturnError -ExceptionMessage $_.Exception
-                    $Message = "Can't open Exchange Online session from Connect-ExchangeOnline"
-                    New-Office365DSCLogEntry -Error $_ -Message $Message
-                }
-            }
-            else
-            {
-                Write-Verbose $_.Exception
-                $VerbosePreference = 'SilentlyContinue'
-                throw $_
-            }
+            throw $_
         }
     }
     else
     {
-        Write-Verbose -Message "Using Existing ExchangeOnline Session."
-        $Global:OpenExchangeSession = Get-PSSession -Name 'ExchangeOnline' -ErrorAction SilentlyContinue | Where-Object -FilterScript { $_.State -eq 'Opened' }
-        $VerbosePreference = 'SilentlyContinue'
-        $WarningPreference = "SilentlyContinue"
     }
-    return
 }

--- a/Modules/MSCloudLoginAssistant/azureEnvironments.json
+++ b/Modules/MSCloudLoginAssistant/azureEnvironments.json
@@ -34,6 +34,7 @@
         "ActiveDirectoryServiceEndpointResourceId": "https://management.core.chinacloudapi.cn/",
         "MsGraphEndpointResourceId": "https://microsoftgraph.chinacloudapi.cn",
         "AadGraphEndpointResourceId": "https://graph.chinacloudapi.cn",
+        "AzureResourceManagerResourceId": "https://management.chinacloudapi.cn/",
         "ExchangeResourceId": "https://partner.outlook.cn",
         "ExchangePsConnection": "https://partner.outlook.cn/PowerShell"
       }
@@ -52,6 +53,7 @@
         "ActiveDirectoryServiceEndpointResourceId": "https://management.core.usgovcloudapi.net/",
         "MsGraphEndpointResourceId": "https://graph.microsoft.us",
         "AadGraphEndpointResourceId": "https://graph.windows.net",
+        "AzureResourceManagerResourceId": "https://management.usgovcloudapi.net/",
         "ExchangeResourceId": "https://outlook.office365.us",
         "ExchangePsConnection": "https://outlook.office365.us/powershell-liveid",
         "SecurityAndCompliancePsConnection": "https://ps.compliance.protection.office365.us/powershell-liveid" 
@@ -71,6 +73,7 @@
         "ActiveDirectoryServiceEndpointResourceId": "https://management.core.usgovcloudapi.net/",
         "MsGraphEndpointResourceId": "https://dod-graph.microsoft.us",
         "AadGraphEndpointResourceId": "https://graph.windows.net",
+        "AzureResourceManagerResourceId": "https://management.usgovcloudapi.net/",
         "ExchangeResourceId": "https://outlook-dod.office365.us",
         "ExchangePsConnection": "https://webmail.apps.mil/powershell-liveid",
         "SecurityAndCompliancePsConnection": "https://l5.ps.compliance.protection.office365.us/powershell-liveid"    
@@ -90,6 +93,7 @@
         "ActiveDirectoryServiceEndpointResourceId": "https://management.core.cloudapi.de/",
         "MsGraphEndpointResourceId": "https://graph.microsoft.de",
         "AadGraphEndpointResourceId": "https://graph.cloudapi.de",
+        "AzureResourceManagerResourceId": "https://management.microsoftazure.de/",
         "ExchangeResourceId": "https://outlook.office.de",
         "ExchangePsConnection": "https://outlook.office.de/PowerShell-LiveID",
         "SecurityAndCompliancePsConnection": "https://ps.compliance.protection.outlook.de/PowerShell-LiveID"            

--- a/Modules/MSCloudLoginAssistant/azureEnvironments.json
+++ b/Modules/MSCloudLoginAssistant/azureEnvironments.json
@@ -6,7 +6,8 @@
         "AzureAD": "AzureCloud",
         "PnP": "Production",
         "MicrosoftTeams": "TeamsCloud",
-        "PowerPlatforms": "prod"   
+        "PowerPlatforms": "prod",
+        "ExchangeOnline": "O365Default"
       },      
       "Endpoints": {
         "ActiveDirectory": "https://login.microsoftonline.com/",
@@ -27,7 +28,8 @@
         "AzureAD": "AzureChinaCloud",
         "PnP": "China",
         "MicrosoftTeams": "TeamsCloud",
-        "PowerPlatforms": "prod"         
+        "PowerPlatforms": "prod" ,
+        "ExchangeOnline": "O365China"        
       },  
       "Endpoints": {
         "ActiveDirectory": "https://login.chinacloudapi.cn/",
@@ -46,7 +48,8 @@
         "AzureAD": "AzureUSGovernment",
         "PnP": "UsGovernment",
         "MicrosoftTeams": "TeamsGCCH",
-        "PowerPlatforms": "usgovhigh"   
+        "PowerPlatforms": "usgovhigh",
+        "ExchangeOnline": "O365USGovGCCHigh"        
       },     
       "Endpoints": {
         "ActiveDirectory": "https://login.microsoftonline.us/",
@@ -66,7 +69,8 @@
         "AzureAD": "AzureUSGovernment",
         "PnP": "UsGovernment",
         "MicrosoftTeams": "TeamsDOD",
-        "PowerPlatforms": "dod"   
+        "PowerPlatforms": "dod",
+        "ExchangeOnline": "O365USGovDoD"
       },     
       "Endpoints": {
         "ActiveDirectory": "https://login.microsoftonline.us/",
@@ -86,7 +90,8 @@
         "AzureAD": "AzureGermanyCloud",
         "PnP": "Germany",
         "MicrosoftTeams": "TeamsCloud",
-        "PowerPlatforms": "prod"  
+        "PowerPlatforms": "prod",
+        "ExchangeOnline": "O365GermanyCloud"
       },   
       "Endpoints": {
         "ActiveDirectory": "https://login.microsoftonline.de/",


### PR DESCRIPTION
The previous attempt from a couple of months ago has some dynamic patching to circumvent a issue where the certificate was not found since it was only looked for in the CurrentUser store. The newer EXO version looks at the localmachine also. Will definitely check once more when everything is inside SysKit Trace.
I tried to get PowerApps to work with application identity but even though the option to use it is there, it simply does not work. I believe they are trying to future proof the code.

here is a person with similar problems:
https://powerusers.microsoft.com/t5/Power-Apps-Governance-and/Add-PowerAppsAccount-using-ClientSecret-in-PowerApps-PowerShell/td-p/660323
