### PR TITLE
Better Remote Sessions logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "powershell.scriptAnalysis.enable": true,
+    "powershell.scriptAnalysis.settingsPath": ".vscode/ScriptAnalyzerSettings.psd1",
+    "powershell.codeFormatting.openBraceOnSameLine": false,
+    "powershell.codeFormatting.newLineAfterOpenBrace": false,
+    "powershell.codeFormatting.newLineAfterCloseBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": true,
+    "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "powershell.codeFormatting.preset": "Custom",
+}

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psd1
@@ -9,31 +9,31 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule = 'MSCloudLoginAssistant.psm1'
+    RootModule             = 'MSCloudLoginAssistant.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.3'
+    ModuleVersion          = '1.0.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
 
     # ID used to uniquely identify this module
-    GUID = 'ca0435a6-ea50-4aa6-8f97-5d031fdc5abe'
+    GUID                   = 'ca0435a6-ea50-4aa6-8f97-5d031fdc5abe'
 
     # Author of this module
-    Author = 'Microsoft Corporation'
+    Author                 = 'Microsoft Corporation'
 
     # Company or vendor of this module
-    CompanyName = 'Microsoft Corporation'
+    CompanyName            = 'Microsoft Corporation'
 
     # Copyright statement for this module
-    Copyright = '(c) 2020 Microsoft Corporation. All rights reserved.'
+    Copyright              = '(c) 2020 Microsoft Corporation. All rights reserved.'
 
     # Description of the functionality provided by this module
-    Description = 'Checks the current status of connections to (and as required, prompts for login to) various Microsoft Cloud platforms.'
+    Description            = 'Checks the current status of connections to (and as required, prompts for login to) various Microsoft Cloud platforms.'
 
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion      = '5.1'
 
     # Name of the Windows PowerShell host required by this module
     # PowerShellHostName = ''
@@ -51,13 +51,13 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules = @(@{
-        ModuleName      = "AzureAD"
-        RequiredVersion = "2.0.2.4"	
-    })
+    RequiredModules        = @(@{
+            ModuleName      = "AzureAD"
+            RequiredVersion = "2.0.2.4"	
+        })
 
     # Assemblies that must be loaded prior to importing this module    
-    RequiredAssemblies = @(".\Utilities\MsGrapgModuleAuthFix\SysKit.MsGraphAuthModulePatching.dll")
+    RequiredAssemblies     = @(".\Utilities\MsGrapgModuleAuthFix\SysKit.MsGraphAuthModulePatching.dll")
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     # ScriptsToProcess = @()
@@ -69,7 +69,7 @@
     # FormatsToProcess = @()
 
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-    NestedModules     = @(
+    NestedModules          = @(
         'Workloads\Azure.psm1',
         'Workloads\AzureAD.psm1',
         'Workloads\ExchangeOnline.psm1',
@@ -81,20 +81,21 @@
         'Workloads\SharePointOnline.psm1',
         'Workloads\SkypeForBusiness.psm1',
         'Workloads\Teams.psm1',
-        'Utilities\Adal.psm1'
+        'Utilities\Adal.psm1',
+        'Utilities\PsSessionRetry.psm1'
     )
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     #FunctionsToExport = ''
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-    CmdletsToExport = @('Test-MSCloudLogin', 'Get-SPOAdminUrl', 'Get-SPORootSiteUrl')
+    CmdletsToExport        = @('Test-MSCloudLogin', 'Get-SPOAdminUrl', 'Get-SPORootSiteUrl')
 
     # Variables to export from this module
-    VariablesToExport = '*'
+    VariablesToExport      = '*'
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport = @()
+    AliasesToExport        = @()
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()
@@ -106,12 +107,12 @@
     # FileList = @()
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-    PrivateData = @{
+    PrivateData            = @{
 
         PSData = @{
 
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags = 'Azure', 'Az', 'AzureAD', 'Cloud', 'Office365', 'PnP', 'MicrosoftTeams', "ExchangeOnline", "SharePointOnline"
+            Tags       = 'Azure', 'Az', 'AzureAD', 'Cloud', 'Office365', 'PnP', 'MicrosoftTeams', "ExchangeOnline", "SharePointOnline"
 
             # A URL to the license for this module.
             # LicenseUri = ''

--- a/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
+++ b/Modules/MSCloudLoginAssistant/MSCloudLoginAssistant.psm1
@@ -18,10 +18,10 @@ function Test-MSCloudLogin
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("Azure","AzureAD","SharePointOnline","ExchangeOnline", `
-                     "SecurityComplianceCenter","MSOnline","PnP","PowerPlatforms", `
-                     "MicrosoftTeams","SkypeForBusiness", "MicrosoftGraph")]
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Azure", "AzureAD", "SharePointOnline", "ExchangeOnline", `
+                "SecurityComplianceCenter", "MSOnline", "PnP", "PowerPlatforms", `
+                "MicrosoftTeams", "SkypeForBusiness", "MicrosoftGraph")]
         [System.String]
         $Platform,
 
@@ -51,7 +51,7 @@ function Test-MSCloudLogin
         $Global:UseModernAuth = $UseModernAuth.IsPresent
     }
 
-    if($Global:appIdentityParams.AppSecret -and !$Global:appIdentityParams.ServicePrincipalCredentials)
+    if ($Global:appIdentityParams.AppSecret -and !$Global:appIdentityParams.ServicePrincipalCredentials)
     {
         $secpasswd = ConvertTo-SecureString $Global:appIdentityParams.AppSecret -AsPlainText -Force
         $spCreds = New-Object System.Management.Automation.PSCredential ($Global:appIdentityParams.AppId, $secpasswd)
@@ -159,7 +159,7 @@ function Get-SPORootSiteUrl
         return $Global:SPORootSiteUrl
     }
 
-    if($Global:UseApplicationIdentity)
+    if ($Global:UseApplicationIdentity)
     {
         Write-Verbose -Message "Retrieving SharePoint Online root site url with MS graph api..."
 
@@ -194,11 +194,11 @@ function Get-SPORootSiteUrl
 
 
         Write-Verbose -Message "Getting SharePoint Online root site URL..."
-        $defaultDomain = Get-AzureADDomain | Where-Object {$_.Name -like "*.onmicrosoft.com" -and $_.IsInitial -eq $true} # We don't use IsDefault here because the default could be a custom domain
+        $defaultDomain = Get-AzureADDomain | Where-Object { $_.Name -like "*.onmicrosoft.com" -and $_.IsInitial -eq $true } # We don't use IsDefault here because the default could be a custom domain
 
         if ($null -eq $defaultDomain)
         {
-            $defaultDomain = Get-AzureADDomain | Where-Object {$_.Name -like "*.onmicrosoft.de" -and $_.IsInitial -eq $true}
+            $defaultDomain = Get-AzureADDomain | Where-Object { $_.Name -like "*.onmicrosoft.de" -and $_.IsInitial -eq $true }
             $domain = '.onmicrosoft.de'
             $tenantName = $defaultDomain[0].Name.Replace($domain, '')
             if ($Global:CloudEnvironment -eq 'Germany')
@@ -302,15 +302,15 @@ function Init-ApplicationIdentity
     )
 
     Init-ApplicationIdentityCore -Tenant $Tenant `
-     -AppId $AppId `
-     -AppSecret $AppSecret `
-     -CertificateThumbprint $CertificateThumbprint `
-     -TokenCacheLocation $TokenCacheLocation `
-     -TokenCacheEntropy $TokenCacheEntropy `
-     -TokenCacheDataProtectionScope  $TokenCacheDataProtectionScope `
-     -OnBehalfOfUserPrincipalName $OnBehalfOfUserPrincipalName `
-     -AzureCloudEnvironmentName $AzureCloudEnvironmentName `
-     -Force
+        -AppId $AppId `
+        -AppSecret $AppSecret `
+        -CertificateThumbprint $CertificateThumbprint `
+        -TokenCacheLocation $TokenCacheLocation `
+        -TokenCacheEntropy $TokenCacheEntropy `
+        -TokenCacheDataProtectionScope  $TokenCacheDataProtectionScope `
+        -OnBehalfOfUserPrincipalName $OnBehalfOfUserPrincipalName `
+        -AzureCloudEnvironmentName $AzureCloudEnvironmentName `
+        -Force
 }
 
 function Init-ApplicationIdentityCore
@@ -364,33 +364,33 @@ function Init-ApplicationIdentityCore
         $Global:UseApplicationIdentity = $null -ne $Global:appIdentityParams -or ![string]::IsNullOrEmpty($AppId) -or ![string]::IsNullOrEmpty($AppSecret) -or ![string]::IsNullOrEmpty($CertificateThumbprint)
     }
 
-    if($Global:UseApplicationIdentity -and !$Global:appIdentityParams -or $Force)
+    if ($Global:UseApplicationIdentity -and !$Global:appIdentityParams -or $Force)
     {
-        if(!$AppId -or (!$AppSecret -and !$CertificateThumbprint))
+        if (!$AppId -or (!$AppSecret -and !$CertificateThumbprint))
         {
             throw "When connecting with an application identity the ApplicationId and the AppSecret or CertificateThumbprint parameters must be provided"
         }
 
-        if(-not $Tenant)
+        if (-not $Tenant)
         {
             throw "The tenant must be specified when connecting with an application identity"
         }
 
-        if(!$AzureCloudEnvironmentName)
+        if (!$AzureCloudEnvironmentName)
         {
             $AzureCloudEnvironmentName = "AzureCloud"
         }
 
         $Global:appIdentityParams = @{
-            AppId = $AppId
-            AppSecret = $AppSecret
-            CertificateThumbprint = $CertificateThumbprint
-            Tenant = $Tenant
-            OnBehalfOfUserPrincipalName = $OnBehalfOfUserPrincipalName
-            TokenCacheLocation = $TokenCacheLocation
-            TokenCacheEntropy = $TokenCacheEntropy
+            AppId                         = $AppId
+            AppSecret                     = $AppSecret
+            CertificateThumbprint         = $CertificateThumbprint
+            Tenant                        = $Tenant
+            OnBehalfOfUserPrincipalName   = $OnBehalfOfUserPrincipalName
+            TokenCacheLocation            = $TokenCacheLocation
+            TokenCacheEntropy             = $TokenCacheEntropy
             TokenCacheDataProtectionScope = $TokenCacheDataProtectionScope
-            AzureCloudEnvironmentName = $AzureCloudEnvironmentName
+            AzureCloudEnvironmentName     = $AzureCloudEnvironmentName
         }
     }
 
@@ -417,11 +417,11 @@ function Grant-OnBehalfConsent
     }
 
     $userIdentifier = [Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier]::AnyUser
-    if($UserPrincipalName)
+    if ($UserPrincipalName)
     {
         $userIdentifier = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList $UserPrincipalName, "OptionalDisplayableId"
     }
-    elseif($Global:appIdentityParams.OnBehalfOfUserPrincipalName)
+    elseif ($Global:appIdentityParams.OnBehalfOfUserPrincipalName)
     {
         $userIdentifier = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList $Global:appIdentityParams.OnBehalfOfUserPrincipalName, "OptionalDisplayableId"
     }
@@ -471,7 +471,7 @@ function New-ADALServiceInfo
 
     if (-not ([System.Management.Automation.PSTypeName]'Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext').Type)
     {
-       Add-Type -Path $AzureADDLL | Out-Null
+        Add-Type -Path $AzureADDLL | Out-Null
     }
 
     $TenantInfo = Get-TenantLoginEndPoint -TenantName $TenantName -AzureCloudEnvironmentName $AzureCloudEnvironmentName
@@ -487,15 +487,15 @@ function New-ADALServiceInfo
     $PromptBehavior = [Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto
     $Service = @{}
     $tokenCacheInstance = $null
-    if($TokenCacheLocation)
+    if ($TokenCacheLocation)
     {
-       $absPath = [System.IO.Path]::GetFullPath( [System.IO.Path]::Combine($PSScriptRoot, $TokenCacheLocation))
-       $tokenCacheInstance = Get-PersistedTokenCacheInstance -FilePath $absPath -TokenCacheEntropy $TokenCacheEntropy -TokenCacheDataProtectionScope $TokenCacheDataProtectionScope
+        $absPath = [System.IO.Path]::GetFullPath( [System.IO.Path]::Combine($PSScriptRoot, $TokenCacheLocation))
+        $tokenCacheInstance = Get-PersistedTokenCacheInstance -FilePath $absPath -TokenCacheEntropy $TokenCacheEntropy -TokenCacheDataProtectionScope $TokenCacheDataProtectionScope
     }
     $Service["authContext"] = [Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext]::new($authority, $false, $tokenCacheInstance)
     $Service["platformParam"] = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $PromptBehavior
 
-    if($UserPrincipalName)
+    if ($UserPrincipalName)
     {
         $Service["userId"] = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList $UserPrincipalName, "OptionalDisplayableId"
     }
@@ -586,19 +586,19 @@ function Get-OnBehalfOfAuthResult
         Add-Type -Path $AzureADDLL | Out-Null
     }
 
-    if(!$Global:appIdentityParams.CertificateThumbprint)
+    if (!$Global:appIdentityParams.CertificateThumbprint)
     {
         throw "Only certificate auth currently implemented"
     }
     $thumbprint = $Global:appIdentityParams.CertificateThumbprint
 
-    $cert = Get-ChildItem -path "Cert:\*$thumbprint" -Recurse | Where-Object { $_.HasPrivateKey }| Select-Object -First 1
+    $cert = Get-ChildItem -path "Cert:\*$thumbprint" -Recurse | Where-Object { $_.HasPrivateKey } | Select-Object -First 1
 
-    if($UserPrincipalName)
+    if ($UserPrincipalName)
     {
         $userIdentifier = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList $UserPrincipalName, "OptionalDisplayableId"
     }
-    elseif($Global:appIdentityParams.OnBehalfOfUserPrincipalName)
+    elseif ($Global:appIdentityParams.OnBehalfOfUserPrincipalName)
     {
         $userIdentifier = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier" -ArgumentList $Global:appIdentityParams.OnBehalfOfUserPrincipalName, "OptionalDisplayableId"
     }
@@ -659,13 +659,13 @@ function Get-AppIdentityAuthResult
         Add-Type -Path $AzureADDLL | Out-Null
     }
 
-    if(!$Global:appIdentityParams.CertificateThumbprint)
+    if (!$Global:appIdentityParams.CertificateThumbprint)
     {
         throw "Only certificate auth currently implemented"
     }
     $thumbprint = $Global:appIdentityParams.CertificateThumbprint
 
-    $cert = Get-ChildItem -path "Cert:\*$thumbprint" -Recurse | Where-Object { $_.HasPrivateKey }| Select-Object -First 1
+    $cert = Get-ChildItem -path "Cert:\*$thumbprint" -Recurse | Where-Object { $_.HasPrivateKey } | Select-Object -First 1
     $certAssertion = [Microsoft.IdentityModel.Clients.ActiveDirectory.ClientAssertionCertificate]::new($Global:appIdentityParams.AppId, $cert)
     $authResultTask = $Global:ADALAppServicePoint.authContext.AcquireTokenAsync($TargetUri.ToString(), $certAssertion)
 
@@ -731,7 +731,7 @@ function Get-AccessToken
 
             if (-not ([System.Management.Automation.PSTypeName]'Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext').Type)
             {
-               Add-Type -Path $AzureADDLL | Out-Null
+                Add-Type -Path $AzureADDLL | Out-Null
             }
 
             $UserPasswordCreds = [Microsoft.IdentityModel.Clients.ActiveDirectory.UserPasswordCredential]::new($Credentials.UserName, $Credentials.Password)
@@ -745,7 +745,7 @@ function Get-AccessToken
             $token = $authResult.result.AccessToken
             return $token
         } -ArgumentList @($targetUri, $AuthUri, $ClientId, $Credentials) | Out-Null
-        $job = Get-Job | Where-Object -FilterScript {$_.Name -eq $jobName}
+        $job = Get-Job | Where-Object -FilterScript { $_.Name -eq $jobName }
         do
         {
             Start-Sleep -Seconds 1
@@ -773,7 +773,7 @@ function Get-SkypeForBusinessServiceEndpoint
         [System.String]
         $OverrideDiscoveryUri
     )
-    if(!$OverrideDiscoveryUri)
+    if (!$OverrideDiscoveryUri)
     {
         $OverrideDiscoveryUri = "http://lyncdiscover." + $TargetDomain;
     }
@@ -781,23 +781,33 @@ function Get-SkypeForBusinessServiceEndpoint
     $liveIdUrl = $OverrideDiscoveryUri.ToString() + "?Domain=" + $TargetDomain
 
     $xml = Get-RTCXml -Url $liveIdUrl
-    if(!$xml)
+    if (!$xml)
     {
         Write-Verbose "Did not find anything @ $OverrideDiscoveryUri, will try with initial domain"
         Test-MSCloudLogin -Platform AzureAD
-        $initialDomain = (Get-AzureADDomain | Where-Object -FilterScript { $_.IsInitial}).Name
-        $OverrideDiscoveryUri = "http://lyncdiscover." + $initialDomain;
-        $desiredLink = "External/RemotePowerShell";
-        $liveIdUrl = $OverrideDiscoveryUri.ToString() + "?Domain=" + $initialDomain
-        $xml = Get-RTCXml -Url $liveIdUrl
+        $tenantDomains = Get-AzureADDomain
+        # $initialDomain = ($tenantDomains | Where-Object -FilterScript { $_.IsInitial }).Name
+        # $OverrideDiscoveryUri = "http://lyncdiscover." + $initialDomain;
+        # $desiredLink = "External/RemotePowerShell";
+        # $liveIdUrl = $OverrideDiscoveryUri.ToString() + "?Domain=" + $initialDomain
+        # $xml = Get-RTCXml -Url $liveIdUrl
+
+        if (!$xml)
+        {
+            $defaultDomain = ($tenantDomains | Where-Object -FilterScript { $_.IsDefault }).Name
+            $OverrideDiscoveryUri = "http://lyncdiscover." + $defaultDomain;
+            $desiredLink = "External/RemotePowerShell";
+            $liveIdUrl = $OverrideDiscoveryUri.ToString() + "?Domain=" + $defaultDomain
+            $xml = Get-RTCXml -Url $liveIdUrl
+        }
     }
 
     $root = $xml.AutodiscoverResponse.Root
 
-    $domain = $root.Link | Where-Object -FilterScript {$_.Token -eq 'domain'}
+    $domain = $root.Link | Where-Object -FilterScript { $_.Token -eq 'domain' }
     if ($null -eq $domain)
     {
-        $redirect = $root.Link | Where-Object -FilterScript {$_.Token -eq 'redirect'}
+        $redirect = $root.Link | Where-Object -FilterScript { $_.Token -eq 'redirect' }
 
         if ($null -eq $redirect)
         {
@@ -808,10 +818,10 @@ function Get-SkypeForBusinessServiceEndpoint
         {
             $xml = Get-RTCXml -Url $redirect.href
             $root = $xml.AutodiscoverResponse.Root
-            $domain = $root.Link | Where-Object -FilterScript {$_.Token -eq 'domain'}
+            $domain = $root.Link | Where-Object -FilterScript { $_.Token -eq 'domain' }
             if ($null -eq $domain)
             {
-                $redirect = $root.Link | Where-Object -FilterScript {$_.Token -eq 'redirect'}
+                $redirect = $root.Link | Where-Object -FilterScript { $_.Token -eq 'redirect' }
             }
             else
             {
@@ -820,14 +830,14 @@ function Get-SkypeForBusinessServiceEndpoint
         }
     }
     $xml = Get-RTCXml -Url $domain.href
-    $endpoint = $xml.AutodiscoverResponse.Domain.Link | Where-Object -FilterScript {$_.token -eq $desiredLink}
-    if(!$endpoint)
+    $endpoint = $xml.AutodiscoverResponse.Domain.Link | Where-Object -FilterScript { $_.token -eq $desiredLink }
+    if (!$endpoint)
     {
-        $hybrid = $xml.AutodiscoverResponse.Domain.Link | Where-Object -FilterScript {$_.token -eq 'Hybrid'}
+        $hybrid = $xml.AutodiscoverResponse.Domain.Link | Where-Object -FilterScript { $_.token -eq 'Hybrid' }
         return Get-SkypeForBusinessServiceEndpoint -TargetDomain $TargetDomain -OverrideDiscoveryUri $hybrid.href
     }
 
-    $endpointUrl = $endpoint.href.Replace("/OcsPowershellLiveId","/OcsPowershellOAuth")
+    $endpointUrl = $endpoint.href.Replace("/OcsPowershellLiveId", "/OcsPowershellOAuth")
     return [Uri]::new($endpointUrl)
 }
 
@@ -875,7 +885,7 @@ function Get-SkypeForBusinessAccessInfo
     $clientId = $null
     if ($end -gt $start)
     {
-        $clientId = $header.Substring($start, $end-$start)
+        $clientId = $header.Substring($start, $end - $start)
     }
 
     # Get Auth Url
@@ -885,12 +895,12 @@ function Get-SkypeForBusinessAccessInfo
     $authUrl = $null
     if ($end -gt $start)
     {
-        $authUrl = $header.Substring($start, $end-$start)
+        $authUrl = $header.Substring($start, $end - $start)
     }
 
     $result = @{
         ClientID = $clientId
-        AuthUrl = $authUrl
+        AuthUrl  = $authUrl
     }
     return $result
 }
@@ -899,7 +909,7 @@ function Get-PowerPlatformTokenInfo
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Audience,
 
@@ -911,7 +921,7 @@ function Get-PowerPlatformTokenInfo
     $jobName = 'AcquireTokenAsync' + (New-Guid).ToString()
     Start-Job -Name $jobName -ScriptBlock {
         Param(
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory = $true)]
             [System.Management.Automation.PSCredential]
             $O365Credentials,
 
@@ -924,7 +934,7 @@ function Get-PowerPlatformTokenInfo
             $WarningPreference = 'SilentlyContinue'
             Import-Module -Name 'Microsoft.PowerApps.Administration.PowerShell' -Force
             $loginEndpoint = Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName ActiveDirectory
-            $authContext = New-Object Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext($loginEndpoint+"common");
+            $authContext = New-Object Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext($loginEndpoint + "common");
             $credential = [Microsoft.IdentityModel.Clients.ActiveDirectory.UserCredential]::new($O365Credentials.Username, $O365Credentials.Password)
             $authResult = $authContext.AcquireToken($Audience, "1950a258-227b-4e31-a9cf-717495945fc2", $credential);
 
@@ -957,7 +967,7 @@ function Get-PowerPlatformTokenInfo
         }
     } -ArgumentList @($Credentials, $Audience) | Out-Null
 
-    $job = Get-Job | Where-Object -FilterScript {$_.Name -eq $jobName}
+    $job = Get-Job | Where-Object -FilterScript { $_.Name -eq $jobName }
     do
     {
         Start-Sleep -Seconds 1
@@ -969,23 +979,27 @@ function Get-PowerPlatformTokenInfo
 
 
 
-$onAssemblyResolveEventHandler = [ResolveEventHandler]{
+$onAssemblyResolveEventHandler = [ResolveEventHandler] {
     param($sender, $e)
 
     Write-Verbose "ResolveEventHandler: Attempting FullName resolution of $($e.Name)"
-    foreach($assembly in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
-        if ($assembly.FullName -eq $e.Name) {
+    foreach ($assembly in [System.AppDomain]::CurrentDomain.GetAssemblies())
+    {
+        if ($assembly.FullName -eq $e.Name)
+        {
             Write-Host "Successful FullName resolution of $($e.Name)"
             return $assembly
         }
     }
 
     Write-Verbose "ResolveEventHandler: Attempting name-only resolution of $($e.Name)"
-    foreach($assembly in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
+    foreach ($assembly in [System.AppDomain]::CurrentDomain.GetAssemblies())
+    {
         # Get just the name from the FullName (no version)
         $assemblyName = $assembly.FullName.Substring(0, $assembly.FullName.IndexOf(", "))
 
-        if ($e.Name.StartsWith($($assemblyName + ","))) {
+        if ($e.Name.StartsWith($($assemblyName + ",")))
+        {
 
             Write-Verbose "Successful name-only (no version) resolution of $assemblyName"
             return $assembly
@@ -999,7 +1013,7 @@ $anyDllVersionResolutionEnabled = $false
 
 function Enable-AppDomainLoadAnyVersionResolution
 {
-    if($Script:anyDllVersionResolutionEnabled)
+    if ($Script:anyDllVersionResolutionEnabled)
     {
         return
     }
@@ -1012,7 +1026,7 @@ function Enable-AppDomainLoadAnyVersionResolution
 
 function Disable-AppDomainLoadAnyVersionResolution
 {
-    if(!$Script:anyDllVersionResolutionEnabled)
+    if (!$Script:anyDllVersionResolutionEnabled)
     {
         return
     }
@@ -1037,12 +1051,12 @@ function Get-AzureEnvironmentEndpoint
 
     Ensure-AzureCloudEnvironmentsFromConfigFile
 
-    if(!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName)
+    if (!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName)
     {
         throw "The $AzureCloudEnvironmentName environment is not registered."
     }
 
-    if(!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName.Endpoints.$EndpointName)
+    if (!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName.Endpoints.$EndpointName)
     {
         throw "$AzureCloudEnvironments is not registered for the $EndpointName cloud environment."
     }
@@ -1052,7 +1066,7 @@ function Get-AzureEnvironmentEndpoint
 
 function Ensure-AzureCloudEnvironmentsFromConfigFile
 {
-    if(!$Global:AzureCloudEnvironments)
+    if (!$Global:AzureCloudEnvironments)
     {
         $configFilePath = Join-Path -Path $PSScriptRoot -ChildPath "azureEnvironments.json"
         $Global:AzureCloudEnvironments = Get-Content -Path $configFilePath | ConvertFrom-Json
@@ -1067,22 +1081,22 @@ function Get-PsModuleAzureEnvironmentName
         [System.String]
         $AzureCloudEnvironmentName,
 
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("Azure","AzureAD","SharePointOnline","ExchangeOnline", `
-                     "SecurityComplianceCenter","MSOnline","PnP","PowerPlatforms", `
-                     "MicrosoftTeams","SkypeForBusiness", "MicrosoftGraph")]
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Azure", "AzureAD", "SharePointOnline", "ExchangeOnline", `
+                "SecurityComplianceCenter", "MSOnline", "PnP", "PowerPlatforms", `
+                "MicrosoftTeams", "SkypeForBusiness", "MicrosoftGraph")]
         [System.String]
         $Platform
     )
 
     Ensure-AzureCloudEnvironmentsFromConfigFile
 
-    if(!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName)
+    if (!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName)
     {
         throw "The $AzureCloudEnvironmentName environment is not registered."
     }
 
-    if(!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName.PsModuleEnvironmentNames.$Platform)
+    if (!$Global:AzureCloudEnvironments.$AzureCloudEnvironmentName.PsModuleEnvironmentNames.$Platform)
     {
         throw "$AzureCloudEnvironments does not have a Ps Module name defined for the $Platform platform."
     }
@@ -1108,9 +1122,10 @@ function Get-MSCloudLoginOrganizationName
 
     Test-MSCloudLogin -Platform AzureAD
 
-    $domain = Get-AzureADDomain  | where-object {$_.IsInitial -eq $True} | select Name
+    $domain = Get-AzureADDomain  | where-object { $_.IsInitial -eq $True } | select Name
 
-    if ($null -ne $domain){
+    if ($null -ne $domain)
+    {
 
         return $domain.Name
     }

--- a/Modules/MSCloudLoginAssistant/Utilities/PsSessionRetry.psm1
+++ b/Modules/MSCloudLoginAssistant/Utilities/PsSessionRetry.psm1
@@ -1,26 +1,26 @@
 function Ensure-RemotePsSession
 {
-    [CmdletBinding()]   
+    [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]        
+        [Parameter(Mandatory = $true)]
         $RemoteSessionName,
 
-        [Parameter(Mandatory = $true)]        
+        [Parameter(Mandatory = $true)]
         $TestModuleLoadedCommand,
 
-        [Parameter(Mandatory = $true)]        
+        [Parameter(Mandatory = $true)]
         $MaxConnectionsMessageSearchString,
 
-        [Parameter(Mandatory = $true)]        
+        [Parameter(Mandatory = $true)]
         [ScriptBlock]
         $CreateSessionScriptBlock,
 
-        [Parameter(Mandatory = $true)]        
+        [Parameter(Mandatory = $true)]
         [ScriptBlock]
         $ExistingSessionPredicate,
 
-        [Parameter()]        
+        [Parameter()]
         [int]
         $MaxAttempts = 12
     )
@@ -34,7 +34,7 @@ function Ensure-RemotePsSession
         Remove-Session $sessionsToClose[$i]
     }
     if ($activeSessions.Length -ge 1)
-    {        
+    {
         $command = Get-Command $TestModuleLoadedCommand -ErrorAction 'SilentlyContinue'
         if ($null -ne $command)
         {
@@ -46,7 +46,7 @@ function Ensure-RemotePsSession
     }
 
 
-    $connectionTriesCounter = 0   
+    $connectionTriesCounter = 0
     $createdSession = $false
     do
     {
@@ -62,7 +62,7 @@ function Ensure-RemotePsSession
         try
         {
             Write-Verbose -Message "Attempting to create a remote session for $RemoteSessionName"
-            Invoke-Command $CreateSessionScriptBlock            
+            Invoke-Command $CreateSessionScriptBlock
             $createdSession = $true
             Write-Verbose -Message "Successfully connected to $RemoteSessionName"
         }

--- a/Modules/MSCloudLoginAssistant/Utilities/PsSessionRetry.psm1
+++ b/Modules/MSCloudLoginAssistant/Utilities/PsSessionRetry.psm1
@@ -1,0 +1,97 @@
+function Ensure-RemotePsSession
+{
+    [CmdletBinding()]   
+    param
+    (
+        [Parameter(Mandatory = $true)]        
+        $RemoteSessionName,
+
+        [Parameter(Mandatory = $true)]        
+        $TestModuleLoadedCommand,
+
+        [Parameter(Mandatory = $true)]        
+        $MaxConnectionsMessageSearchString,
+
+        [Parameter(Mandatory = $true)]        
+        [ScriptBlock]
+        $CreateSessionScriptBlock,
+
+        [Parameter(Mandatory = $true)]        
+        [ScriptBlock]
+        $ExistingSessionPredicate,
+
+        [Parameter()]        
+        [int]
+        $MaxAttempts = 12
+    )
+    $existingSessions = Get-PSSession | Where-Object -FilterScript $ExistingSessionPredicate
+    [array]$activeSessions = $existingSessions | Where-Object -FilterScript { $_.State -eq 'Opened' }
+    [array] $sessionsToClose = $existingSessions | Where-Object -FilterScript { $_.State -ne 'Opened' }
+    for ($i = 0; $i -lt $sessionsToClose.Length; $i++)
+    {
+        $sessionName = $sessionsToClose[$i].Name
+        Write-Verbose "Closing remote powershell session $sessionName"
+        Remove-Session $sessionsToClose[$i]
+    }
+    if ($activeSessions.Length -ge 1)
+    {        
+        $command = Get-Command $TestModuleLoadedCommand -ErrorAction 'SilentlyContinue'
+        if ($null -ne $command)
+        {
+            return
+        }
+        $module = Import-PSSession $activeSessions[0] -DisableNameChecking -AllowClobber
+        Import-Module $module -Global | Out-Null
+        return
+    }
+
+
+    $connectionTriesCounter = 0   
+    $createdSession = $false
+    do
+    {
+        $CurrentVerbosePreference = $VerbosePreference
+        $CurrentInformationPreference = $InformationPreference
+        $CurrentWarningPreference = $WarningPreference
+        $VerbosePreference = "SilentlyContinue"
+        $InformationPreference = "SilentlyContinue"
+        $WarningPreference = "SilentlyContinue"
+
+        $connectionTriesCounter++
+
+        try
+        {
+            Write-Verbose -Message "Attempting to create a remote session for $RemoteSessionName"
+            Invoke-Command $CreateSessionScriptBlock            
+            $createdSession = $true
+            Write-Verbose -Message "Successfully connected to $RemoteSessionName"
+        }
+        catch
+        {
+            # unfortunatelly there is nothing except the error message that could uniquely identify this case, hello potential localization issues
+            $isMaxAllowedConnectionsError = $null -ne $_.Exception -and $_.Exception.Message.Contains($MaxConnectionsMessageSearchString)
+            if (!$isMaxAllowedConnectionsError)
+            {
+                throw
+            }
+        }
+        finally
+        {
+            $VerbosePreference = $CurrentVerbosePreference
+            $InformationPreference = $CurrentInformationPreference
+            $WarningPreference = $CurrentWarningPreference
+        }
+
+        $shouldRetryConnection = !$createdSession -and $connectionTriesCounter -le $MaxAttempts
+        if ($shouldRetryConnection)
+        {
+            Write-Information "[$connectionTriesCounter/$MaxAttempts] Too many existing workspaces. Waiting an additional 70 seconds for sessions to free up."
+            Start-Sleep -Seconds 70
+        }
+    } while ($shouldRetryConnection)
+
+    if (!$createdSession)
+    {
+        throw "The maximum retry attempt to create a $RemoteSessionName connection has been exceeded."
+    }
+}

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
@@ -14,98 +14,28 @@ function Connect-MSCloudLoginExchangeOnline
     $psConnectionUri = Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName ExchangePsConnection
     $uriObj = [Uri]::new($psConnectionUri)
     $exchangeHost = $uriObj.Host
-    $existingSessions = Get-PSSession | Where-Object -FilterScript { ($_.ComputerName -like '*outlook.office*' -or $_.ComputerName -like "*$exchangeHost*" ) }
-    [array]$activeSessions = $existingSessions | Where-Object -FilterScript { $_.State -eq 'Opened' }
-    [array] $sessionsToClose = $existingSessions | Where-Object -FilterScript { $_.State -ne 'Opened' }
-    for ($i = 0; $i -lt $sessionsToClose.Length; $i++)
-    {
-        $sessionName = $sessionsToClose[$i].Name
-        Write-Verbose "Closing remote powershell session $sessionName"
-        Remove-Session $sessionsToClose[$i]
-    }
 
-    if ($activeSessions.Length -ge 1)
-    {
-        Write-Verbose -Message "Found {$($activeSessions.Length)} existing Exchange Online Session"
-        $command = Get-Command "Get-AcceptedDomain" -ErrorAction 'SilentlyContinue'
-        if ($null -ne $command)
-        {
-            return
-        }
-        $EXOModule = Import-PSSession $activeSessions[0] -DisableNameChecking -AllowClobber
-        Import-Module $EXOModule -Global | Out-Null
-        return
-    }
-    Write-Verbose -Message "No active Exchange Online session found."
+    
+    $maxConnectionsSearchString = "Fail to create a runspace because you have exceeded the maximum number of connections allowed"
+    
+    Ensure-RemotePsSession -RemoteSessionName "Exchange Online" `
+        -TestModuleLoadedCommand "Get-AcceptedDomain" `
+        -MaxConnectionsMessageSearchString $maxConnectionsSearchString `
+        -ExistingSessionPredicate { ($_.ComputerName -like '*outlook.office*' -or $_.ComputerName -like "*$exchangeHost*" ) } `
+        -CreateSessionScriptBlock {
 
-    #endregion
-    if (-not [String]::IsNullOrEmpty($ApplicationId) -and `
-            -not [String]::IsNullOrEmpty($TenantId) -and `
-            -not [String]::IsNullOrEmpty($CertificateThumbprint))
-    {
         $Organization = Get-MSCloudLoginOrganizationName -ApplicationId $ApplicationId `
             -TenantId $TenantId `
             -CertificateThumbprint $CertificateThumbprint
-        $connectionTriesCounter = 0
-        $maxAttempts = 10
-        $createdSession = $false
-        do
-        {
-            $CurrentVerbosePreference = $VerbosePreference
-            $CurrentInformationPreference = $InformationPreference
-            $CurrentWarningPreference = $WarningPreference
-            $VerbosePreference = "SilentlyContinue"
-            $InformationPreference = "SilentlyContinue"
-            $WarningPreference = "SilentlyContinue"
-
-            $connectionTriesCounter++
-
-            try
-            {
-                Write-Verbose -Message "Attempting to connect to Exchange Online using AAD App {$ApplicationID}"
-                Connect-ExchangeOnline -AppId $ApplicationId `
-                    -Organization $Organization `
-                    -CertificateThumbprint $CertificateThumbprint `
-                    -ShowBanner:$false `
-                    -ShowProgress:$false `
-                    -ConnectionUri $psConnectionUri `
-                    -AzureADAuthorizationEndpointUri $AuthorizationUrl `
-                    -ExchangeEnvironmentName $ExoEnvName `
-                    -Verbose:$false | Out-Null
-                $createdSession = $true
-                Write-Verbose -Message "Successfully connected to Exchange Online using AAD App {$ApplicationID}"
-            }
-            catch
-            {
-                # unfortunatelly there is nothing except the error message that could uniquely identify this case, hello potential localization issues
-                $isMaxAllowedConnectionsError = $null -ne $_.Exception -and $_.Exception.Message.Contains('Fail to create a runspace because you have exceeded the maximum number of connections allowed')
-                if (!$isMaxAllowedConnectionsError)
-                {
-                    throw
-                }
-            }
-            finally
-            {
-                $VerbosePreference = $CurrentVerbosePreference
-                $InformationPreference = $CurrentInformationPreference
-                $WarningPreference = $CurrentWarningPreference
-            }
-
-            $shouldRetryConnection = !$createdSession -and $connectionTriesCounter -le $maxAttempts
-            if ($shouldRetryConnection)
-            {
-                Write-Information "[$connectionTriesCounter/$maxAttempts] Too many existing workspaces. Waiting an additional 70 seconds for sessions to free up."
-                Start-Sleep -Seconds 70
-            }
-        } while ($shouldRetryConnection)
-
-        if (!$createdSession)
-        {
-            throw "The maximum retry attempt to create a EXO managment connection has been exceeded."
-        }
-    }
-    else
-    {
-        throw "Connecting without an application identity is not supported"
+            
+        Connect-ExchangeOnline -AppId $ApplicationId `
+            -Organization $Organization `
+            -CertificateThumbprint $CertificateThumbprint `
+            -ShowBanner:$false `
+            -ShowProgress:$false `
+            -ConnectionUri $psConnectionUri `
+            -AzureADAuthorizationEndpointUri $AuthorizationUrl `
+            -ExchangeEnvironmentName $ExoEnvName `
+            -Verbose:$false | Out-Null
     }
 }

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
@@ -93,8 +93,8 @@ function Connect-MSCloudLoginExchangeOnline
             $shouldRetryConnection = !$createdSession -and $connectionTriesCounter -le $maxAttempts
             if ($shouldRetryConnection)
             {
-                Write-Information "[$connectionTriesCounter/$maxAttempts] Too many existing workspaces. Waiting an additional 60 seconds for sessions to free up."
-                Start-Sleep -Seconds 60
+                Write-Information "[$connectionTriesCounter/$maxAttempts] Too many existing workspaces. Waiting an additional 70 seconds for sessions to free up."
+                Start-Sleep -Seconds 70
             }
         } while ($shouldRetryConnection)
 

--- a/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/ExchangeOnline.psm1
@@ -19,7 +19,8 @@ function Connect-MSCloudLoginExchangeOnline
     [array] $sessionsToClose = $existingSessions | Where-Object -FilterScript { $_.State -ne 'Opened' }
     for ($i = 0; $i -lt $sessionsToClose.Length; $i++)
     {
-        Write-Verbose "Closing session $($sessionsToClose[$i].Name)"
+        $sessionName = $sessionsToClose[$i].Name
+        Write-Verbose "Closing remote powershell session $sessionName"
         Remove-Session $sessionsToClose[$i]
     }
 

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -61,11 +61,12 @@ function Connect-MSCloudLoginSecurityCompliance
                 -AzureADAuthorizationEndpointUri $authorizationUrl `
                 -Verbose:$false -ErrorAction Stop | Out-Null
             $createdSession = $true
+            Write-Verbose -Message "Successfully connected to the Security And Compliance center"
         }
         catch
         {
             # unfortunatelly there is nothing except the error message that could uniquely identify this case, hello potential localization issues
-            $isMaxAllowedConnectionsError = $_.ErrorDetails.ToString().Contains('Fail to create a runspace because you have exceeded the maximum number of connections allowed')
+            $isMaxAllowedConnectionsError = $null -ne $_.Exception -and $_.Exception.Message.Contains('Fail to create a runspace because you have exceeded the maximum number of connections allowed')
             if (!$isMaxAllowedConnectionsError)
             {
                 throw

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -7,8 +7,6 @@ function Connect-MSCloudLoginSecurityCompliance
         throw "The SecurityComplianceCenter Platform does not support connecting with application identity."
     }
 
-
-
     $WarningPreference = 'SilentlyContinue'
     $ProgressPreference = 'SilentlyContinue'
     $InformationPreference = 'Continue'
@@ -18,6 +16,7 @@ function Connect-MSCloudLoginSecurityCompliance
     $uriObj = [Uri]::new($ConnectionUrl)
     $scHost = $uriObj.Host
 
+    
     $maxConnectionsSearchString = "Fail to create a runspace because you have exceeded the maximum number of connections allowed"
     
     Ensure-RemotePsSession -RemoteSessionName "Security and Compliance" `

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -23,7 +23,8 @@ function Connect-MSCloudLoginSecurityCompliance
     [array] $sessionsToClose = $existingSessions | Where-Object -FilterScript { $_.State -ne 'Opened' }
     for ($i = 0; $i -lt $sessionsToClose.Length; $i++)
     {
-        Write-Verbose "Closing session $($sessionsToClose[$i].Name)"
+        $sessionName = $sessionsToClose[$i].Name
+        Write-Verbose "Closing remote powershell session $sessionName"
         Remove-Session $sessionsToClose[$i]
     }
     if ($activeSessions.Length -ge 1)

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -82,8 +82,8 @@ function Connect-MSCloudLoginSecurityCompliance
         $shouldRetryConnection = !$createdSession -and $connectionTriesCounter -le $maxAttempts
         if ($shouldRetryConnection)
         {
-            Write-Information "[$connectionTriesCounter/$maxAttempts] Too many existing workspaces. Waiting an additional 60 seconds for sessions to free up."
-            Start-Sleep -Seconds 60
+            Write-Information "[$connectionTriesCounter/$maxAttempts] Too many existing workspaces. Waiting an additional 70 seconds for sessions to free up."
+            Start-Sleep -Seconds 70
         }
     } while ($shouldRetryConnection)
 

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -2,173 +2,62 @@ function Connect-MSCloudLoginSecurityCompliance
 {
     [CmdletBinding()]
     param()
-    if($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
+    if ($Global:UseApplicationIdentity -and $null -eq $Global:o365Credential)
     {
         throw "The SecurityComplianceCenter Platform does not support connecting with application identity."
     }
-    
-    if ($null -eq $Global:o365Credential)
-    {
-       $Global:o365Credential = Get-Credential -Message "Cloud Credential"
-    }
-    $moduleName = "O365SecurityAndComplianceShell"
+
+
+
     $WarningPreference = 'SilentlyContinue'
+    $ProgressPreference = 'SilentlyContinue'
     $InformationPreference = 'Continue'
+    $authorizationUrl = Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName ActiveDirectory
+    $authorizationUrl += "common"
     $ConnectionUrl = Get-AzureEnvironmentEndpoint -AzureCloudEnvironmentName $Global:appIdentityParams.AzureCloudEnvironmentName -EndpointName SecurityAndCompliancePsConnection
-    $Global:SessionSecurityCompliance = Get-PSSession | `
-        Where-Object { `
-            ($_.ComputerName -like "*ps.compliance.protection.outlook.com" -or `
-            $_.ComputerName -like "*ps.compliance.protection.office365.us" -or `
-            $_.ComputerName -like "*ps.compliance.protection.outlook.de") `
-            -and $_.State -eq "Opened"`
-        }
+    $uriObj = [Uri]::new($ConnectionUrl)
+    $scHost = $uriObj.Host
 
-
-    if ($null -eq $Global:SessionSecurityCompliance)
+    $existingSessions = Get-PSSession | Where-Object -FilterScript { ($_.ComputerName -like '*.ps.compliance.protection*' -or $_.ComputerName -like "*$scHost*" ) }
+    [array]$activeSessions = $existingSessions | Where-Object -FilterScript { $_.State -eq 'Opened' }
+    [array] $sessionsToClose = $existingSessions | Where-Object -FilterScript { $_.State -ne 'Opened' }
+    for ($i = 0; $i -lt $sessionsToClose.Length; $i++)
     {
-        try
+        Write-Verbose "Closing session $($sessionsToClose[$i].Name)"
+        Remove-Session $sessionsToClose[$i]
+    }
+    if ($activeSessions.Length -ge 1)
+    {
+        #  Write-Verbose -Message "Found {$($activeSessions.Length)} existing Security and Compliance Session"
+        $command = Get-Command "Get-ComplianceSearch" -ErrorAction 'SilentlyContinue'
+        if ($null -ne $command)
         {
-            try
-            {
-                Write-Verbose -Message "Session to Security & Compliance no working session found, creating a new one"
-                $Global:SessionSecurityCompliance = New-PSSession -ConfigurationName "Microsoft.Exchange" `
-                -ConnectionUri $ConnectionUrl `
-                -Credential $O365Credential `
-                -Authentication Basic `
-                -ErrorAction Stop `
-                -AllowRedirection
-            }
-            catch
-            {
-                throw $_
-
-                # we do not have correct different Cloud support, so best not to use this logic
-                # it only leads to confusion
-                # If the connection failed against either the Public or Germany clouds, then attempt to connect
-                # to the GCC Cloud.
-                # try
-                # {
-                #     $CloudEnvironment = "GCC"
-                #     Write-Verbose -Message "Session to Security & Compliance no working session found, creating a new one"
-                #     $Global:SessionSecurityCompliance = New-PSSession -ConfigurationName "Microsoft.Exchange" `
-                #         -ConnectionUri 'https://ps.compliance.protection.office365.us/powershell-liveid/' `
-                #         -Credential $O365Credential `
-                #         -Authentication Basic `
-                #         -ErrorAction Stop `
-                #         -AllowRedirection
-                # }
-                # catch
-                # {
-                #     throw $_
-                # }
-            }
+            return
         }
-        catch
-        {
-            if ($_.ErrorDetails.ToString().Contains('Fail to create a runspace because you have exceeded the maximum number of connections allowed' -and `
-                $CloudEnvironment -ne 'Germany'))
-            {
-                $counter = 1
-                while ($null -eq $Global:SessionSecurityCompliance -and $counter -le 10)
-                {
-                    try
-                    {
-                        $InformationPreference = "Continue"
-                        Write-Information -Message "[$counter/10] Too many existing workspaces. Waiting an additional 60 seconds for sessions to free up."
-                        Start-Sleep -Seconds 60
-                        try
-                        {
-                            $Global:SessionSecurityCompliance = New-PSSession -ConfigurationName "Microsoft.Exchange" `
-                                -ConnectionUri $ConnectionUrl `
-                                -Credential $O365Credential `
-                                -Authentication Basic `
-                                -ErrorAction Stop `
-                                -AllowRedirection
-                        }
-                        catch
-                        {
-                            try
-                            {
-                                $Global:SessionSecurityCompliance = New-PSSession -ConfigurationName "Microsoft.Exchange" `
-                                    -ConnectionUri 'https://ps.compliance.protection.office365.us/powershell-liveid/' `
-                                    -Credential $O365Credential `
-                                    -Authentication Basic `
-                                    -ErrorAction Stop `
-                                    -AllowRedirection
-                            }
-                            catch
-                            {
-                                throw $_
-                            }
-                        }
-                        $InformationPreference = "SilentlyContinue"
-                    }
-                    catch
-                    {}
-                    $counter ++
-                }
-            }
-            else
-            {
-                # SC cannot use our own app identity or delegate so
-                # we only allow app passwords for Security & compliance
-                # if the connection fails we do not want to fallback to Modern authentication since
-                # the script is very likely to be executing within a non interactive environment
-                if($Global:UseApplicationIdentity)
-                {
-                    throw $_
-                }
-                try
-                {
-                    $clientid = "a0c73c16-a7e3-4564-9a95-2bdf47383716";
-                    $ResourceURI = "https://ps.compliance.protection.outlook.com";
-                    $NewConnectionUrl = $ConnectionUrl + '?BasicAuthToOAuthConversion=true'
-                    if ($O365Credential.UserName -like '*.onmicrosoft.de')
-                    {
-                        $ResourceURI = "https://ps.compliance.protection.outlook.de";
-                    }
-                    $RedirectURI = "urn:ietf:wg:oauth:2.0:oob";
-                    $AuthHeader = Get-AuthHeader -UserPrincipalName $Global:o365Credential.UserName `
-                                                  -ResourceURI $ResourceURI -clientID $clientID `
-                                                  -RedirectURI $RedirectURI
-
-                    $Password = ConvertTo-SecureString -AsPlainText $AuthHeader -Force
-
-                    $Ctoken = New-Object System.Management.Automation.PSCredential -ArgumentList $Global:o365Credential.UserName, $Password
-                    $Global:SessionSecurityCompliance = New-PSSession -ConfigurationName Microsoft.Exchange `
-                        -ConnectionUri $NewConnectionUrl `
-                        -Credential $Ctoken `
-                        -Authentication Basic `
-                        -AllowRedirection
-                    if ($null -eq $Global:SessionSecurityCompliance)
-                    {
-                        $Global:SessionSecurityCompliance = New-PSSession -ConfigurationName Microsoft.Exchange `
-                            -ConnectionUri https://ps.compliance.protection.office365.us/powershell-liveid/?BasicAuthToOAuthConversion=true `
-                            -Credential $Ctoken `
-                            -Authentication Basic `
-                            -AllowRedirection
-                    }
-                    $Global:UseModernAuth = $True
-                }
-                catch
-                {
-                    throw $_
-                }
-            }
-        }
+        $SCModule = Import-PSSession $activeSessions[0] -DisableNameChecking -AllowClobber
+        Import-Module $SCModule -Global | Out-Null
+        return
     }
-    else
+
+    $CurrentVerbosePreference = $VerbosePreference
+    $CurrentInformationPreference = $InformationPreference
+    $CurrentWarningPreference = $WarningPreference
+    $VerbosePreference = "SilentlyContinue"
+    $InformationPreference = "SilentlyContinue"
+    $WarningPreference = "SilentlyContinue"
+    try
     {
-        Write-Verbose -Message "Session to Security & Compliance already exists, re-using existing session"
+        Connect-IPPSSession -Credential $Global:o365Credential `
+            -ConnectionUri $ConnectionUrl `
+            -AzureADAuthorizationEndpointUri $authorizationUrl `
+            -Verbose:$false -ErrorAction Stop | Out-Null
     }
-    $WarningPreference = 'SilentlyContinue'
-    if ($null -eq $Global:SCModule)
+    finally
     {
-        $Global:SCModule = Import-PSSession $Global:SessionSecurityCompliance  `
-            -ErrorAction SilentlyContinue `
-            -AllowClobber
-
-        Import-Module $Global:SCModule -Global | Out-Null
+        $VerbosePreference = $CurrentVerbosePreference
+        $InformationPreference = $CurrentInformationPreference
+        $WarningPreference = $CurrentWarningPreference
     }
-    return
+
+
 }

--- a/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
+++ b/Modules/MSCloudLoginAssistant/Workloads/SecurityCompliance.psm1
@@ -18,78 +18,16 @@ function Connect-MSCloudLoginSecurityCompliance
     $uriObj = [Uri]::new($ConnectionUrl)
     $scHost = $uriObj.Host
 
-    $existingSessions = Get-PSSession | Where-Object -FilterScript { ($_.ComputerName -like '*.ps.compliance.protection*' -or $_.ComputerName -like "*$scHost*" ) }
-    [array]$activeSessions = $existingSessions | Where-Object -FilterScript { $_.State -eq 'Opened' }
-    [array] $sessionsToClose = $existingSessions | Where-Object -FilterScript { $_.State -ne 'Opened' }
-    for ($i = 0; $i -lt $sessionsToClose.Length; $i++)
-    {
-        $sessionName = $sessionsToClose[$i].Name
-        Write-Verbose "Closing remote powershell session $sessionName"
-        Remove-Session $sessionsToClose[$i]
-    }
-    if ($activeSessions.Length -ge 1)
-    {
-        #  Write-Verbose -Message "Found {$($activeSessions.Length)} existing Security and Compliance Session"
-        $command = Get-Command "Get-ComplianceSearch" -ErrorAction 'SilentlyContinue'
-        if ($null -ne $command)
-        {
-            return
-        }
-        $SCModule = Import-PSSession $activeSessions[0] -DisableNameChecking -AllowClobber
-        Import-Module $SCModule -Global | Out-Null
-        return
-    }
-
-
-    $connectionTriesCounter = 0
-    $maxAttempts = 10
-    $createdSession = $false
-    do
-    {
-        $CurrentVerbosePreference = $VerbosePreference
-        $CurrentInformationPreference = $InformationPreference
-        $CurrentWarningPreference = $WarningPreference
-        $VerbosePreference = "SilentlyContinue"
-        $InformationPreference = "SilentlyContinue"
-        $WarningPreference = "SilentlyContinue"
-
-        $connectionTriesCounter++
-
-        try
-        {
-            Connect-IPPSSession -Credential $Global:o365Credential `
-                -ConnectionUri $ConnectionUrl `
-                -AzureADAuthorizationEndpointUri $authorizationUrl `
-                -Verbose:$false -ErrorAction Stop | Out-Null
-            $createdSession = $true
-            Write-Verbose -Message "Successfully connected to the Security And Compliance center"
-        }
-        catch
-        {
-            # unfortunatelly there is nothing except the error message that could uniquely identify this case, hello potential localization issues
-            $isMaxAllowedConnectionsError = $null -ne $_.Exception -and $_.Exception.Message.Contains('Fail to create a runspace because you have exceeded the maximum number of connections allowed')
-            if (!$isMaxAllowedConnectionsError)
-            {
-                throw
-            }
-        }
-        finally
-        {
-            $VerbosePreference = $CurrentVerbosePreference
-            $InformationPreference = $CurrentInformationPreference
-            $WarningPreference = $CurrentWarningPreference
-        }
-
-        $shouldRetryConnection = !$createdSession -and $connectionTriesCounter -le $maxAttempts
-        if ($shouldRetryConnection)
-        {
-            Write-Information "[$connectionTriesCounter/$maxAttempts] Too many existing workspaces. Waiting an additional 70 seconds for sessions to free up."
-            Start-Sleep -Seconds 70
-        }
-    } while ($shouldRetryConnection)
-
-    if (!$createdSession)
-    {
-        throw "The maximum retry attempt to create a Security And Complinace connection has been exceeded."
+    $maxConnectionsSearchString = "Fail to create a runspace because you have exceeded the maximum number of connections allowed"
+    
+    Ensure-RemotePsSession -RemoteSessionName "Security and Compliance" `
+        -TestModuleLoadedCommand "Get-ComplianceSearch" `
+        -MaxConnectionsMessageSearchString $maxConnectionsSearchString `
+        -ExistingSessionPredicate { ($_.ComputerName -like '*.ps.compliance.protection*' -or $_.ComputerName -like "*$scHost*" ) } `
+        -CreateSessionScriptBlock {
+        Connect-IPPSSession -Credential $Global:o365Credential `
+            -ConnectionUri $ConnectionUrl `
+            -AzureADAuthorizationEndpointUri $authorizationUrl `
+            -Verbose:$false -ErrorAction Stop | Out-Null
     }
 }


### PR DESCRIPTION
This PR consolidates the Remote PowerShell logic.
Previously a workload either did not have retries or it incorrectly reused older sessions when they were broken.
The logic is in one place now and should be consistent.
This does not mean that there can be no failures with remote PowerShell, but it should not fail for all the following M365 resources when creating a snapshot in SysKit Trace.